### PR TITLE
feat(be):Account 도메인, API 구현

### DIFF
--- a/backend/src/main/java/com/back/domain/account/controller/ApiV1AccountController.java
+++ b/backend/src/main/java/com/back/domain/account/controller/ApiV1AccountController.java
@@ -1,0 +1,61 @@
+package com.back.domain.account.controller;
+
+import com.back.domain.account.dto.AccountDto;
+import com.back.domain.account.dto.RqCreateAccountDto;
+import com.back.domain.account.entity.Account;
+import com.back.domain.account.service.AccountService;
+import com.back.global.rsData.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/accounts")
+@Tag(name = "Account", description = "계좌 컨트롤러")
+public class ApiV1AccountController {
+
+    private final AccountService accountService;
+
+    @PostMapping
+    @Operation(summary = "계좌 등록" , description = "새로운 계좌 등록")
+    public RsData<AccountDto> createAccount(@RequestBody RqCreateAccountDto rqCreateAccountDto) {
+
+        Account account = accountService.createAccount(rqCreateAccountDto);
+        AccountDto accountDto= new AccountDto(account);
+
+        return new RsData("200-1", "계좌가 등록되었습니다.",accountDto);
+    }
+
+    @GetMapping
+    @Operation(summary = "계좌 다건 조회", description = "계좌 다건 조회")
+    public RsData<List<AccountDto>> getAccounts(){
+        List<Account> accounts=accountService.getAcccounts();
+        List<AccountDto> accountDtos = accounts.stream().map(AccountDto::new).toList();
+
+        return new
+                RsData<>("200-1", "계좌 목록을 조회했습니다.", accountDtos);
+    }
+
+
+    @GetMapping("/{accountId}")
+    @Operation(summary = "계좌 단건 조회", description = "계좌 단건 조회")
+    public RsData<AccountDto> getAccount(@PathVariable int accountId){
+        Account account =accountService.getAccount(accountId);
+        AccountDto accountDto = new AccountDto(account);
+
+        return new RsData<>("200-1", "%d번 계좌를 조회했습니다.".formatted(accountId), accountDto);
+    }
+
+    @DeleteMapping("/{accountId}")
+    @Operation(summary = "계좌 삭제", description = "계좌 삭제")
+    public RsData<AccountDto> deleteAccount(@PathVariable int accountId){
+        Account account = accountService.deleteAccount(accountId);
+        AccountDto accountDto=new AccountDto(account);
+
+        return new RsData<>("200-1","%d번 계좌가 삭제되었습니다.".formatted(accountId), accountDto);
+    }
+}

--- a/backend/src/main/java/com/back/domain/account/dto/AccountDto.java
+++ b/backend/src/main/java/com/back/domain/account/dto/AccountDto.java
@@ -1,0 +1,27 @@
+package com.back.domain.account.dto;
+
+import com.back.domain.account.entity.Account;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class AccountDto {
+    private int id;
+    private int memberId;
+    private String name;
+    private  String accountNumber;
+    private Long balance;
+    private LocalDateTime createDate;
+    private LocalDateTime modifyDate;
+
+    public AccountDto(Account account) {
+        this.id = account.getId();
+        this.memberId = account.getMember().getId();
+        this.name = account.getName();
+        this.accountNumber = account.getAccountNumber();
+        this.balance = account.getBalance();
+        this.createDate = account.getCreateDate();
+        this.modifyDate = account.getModifyDate();
+    }
+}

--- a/backend/src/main/java/com/back/domain/account/dto/RqCreateAccountDto.java
+++ b/backend/src/main/java/com/back/domain/account/dto/RqCreateAccountDto.java
@@ -1,0 +1,15 @@
+package com.back.domain.account.dto;
+
+import com.back.domain.account.entity.Account;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RqCreateAccountDto {
+    private int memberId;
+    private String name;
+    private String accountNumber;
+    private Long balance;
+
+}

--- a/backend/src/main/java/com/back/domain/account/entity/Account.java
+++ b/backend/src/main/java/com/back/domain/account/entity/Account.java
@@ -1,0 +1,26 @@
+package com.back.domain.account.entity;
+
+import com.back.domain.member.entity.Member;
+import com.back.global.jpa.entity.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class Account extends BaseEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id",nullable = false)
+    private Member member;
+    private String accountNumber;
+    private Long balance;
+    private String name;
+}

--- a/backend/src/main/java/com/back/domain/account/repository/AccountRepository.java
+++ b/backend/src/main/java/com/back/domain/account/repository/AccountRepository.java
@@ -1,0 +1,7 @@
+package com.back.domain.account.repository;
+
+import com.back.domain.account.entity.Account;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AccountRepository extends JpaRepository<Account,Integer> {
+}

--- a/backend/src/main/java/com/back/domain/account/service/AccountService.java
+++ b/backend/src/main/java/com/back/domain/account/service/AccountService.java
@@ -1,0 +1,47 @@
+package com.back.domain.account.service;
+
+import com.back.domain.account.dto.RqCreateAccountDto;
+import com.back.domain.account.entity.Account;
+import com.back.domain.account.repository.AccountRepository;
+import com.back.domain.member.entity.Member;
+import com.back.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AccountService {
+
+    private final AccountRepository accountRepository;
+    private final MemberRepository memberRepository;
+
+    public Account createAccount(RqCreateAccountDto rqCreateAccountDto) {
+        Member member = memberRepository.findById(rqCreateAccountDto.getMemberId()).orElseThrow(()->new IllegalArgumentException("해당 회원이 존재하지 않습니다."));
+
+        Account account= Account.builder()
+                .member(member)
+                .accountNumber(rqCreateAccountDto.getAccountNumber())
+                .name(rqCreateAccountDto.getName())
+                .balance(rqCreateAccountDto.getBalance())
+                .build();
+
+        return accountRepository.save(account);
+    }
+
+    public List<Account> getAcccounts() {
+        return accountRepository.findAll();}
+
+    public Account getAccount(int accountId) {
+        return accountRepository.findById(accountId).orElseThrow(() -> new IllegalArgumentException("해당 계좌가 존재하지 않습니다. id: " + accountId));
+    }
+
+    public Account deleteAccount(int accountId) {
+        Account account = getAccount(accountId);
+
+        accountRepository.deleteById(accountId);
+
+        return account;
+    }
+}

--- a/backend/src/test/java/com/back/domain/account/controller/ApiV1AccountControllerTest.java
+++ b/backend/src/test/java/com/back/domain/account/controller/ApiV1AccountControllerTest.java
@@ -1,0 +1,80 @@
+package com.back.domain.account.controller;
+
+import com.back.domain.account.repository.AccountRepository;
+import com.back.domain.member.entity.Member;
+import com.back.domain.member.repository.MemberRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ApiV1AccountControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    ObjectMapper objectMapper=new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        memberRepository.save(new Member());
+    }
+
+    @Test
+    @DisplayName("계좌 등록 및 조회")
+    void t1() throws Exception {
+
+        String requestBody =
+                objectMapper.writeValueAsString(Map.of("memberId", 1,
+                        "name", "농협",
+                        "accountNumber", "1234567890",
+                        "balance", 1000));
+
+        // 계좌 등록
+        mockMvc.perform(post("/api/v1/accounts")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.memberId").value(1))
+                .andExpect(jsonPath("$.data.name").value("농협"))
+                .andExpect(jsonPath("$.data.accountNumber").value("1234567890"))
+                .andExpect(jsonPath("$.data.balance").value(1000));
+
+        // 다건 조회
+        mockMvc.perform(get("/api/v1/accounts"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(1));
+
+        // 단건 조회
+        mockMvc.perform(get("/api/v1/accounts/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.memberId").value(1))
+                .andExpect(jsonPath("$.data.name").value("농협"))
+                .andExpect(jsonPath("$.data.accountNumber").value("1234567890"))
+                .andExpect(jsonPath("$.data.balance").value(1000));
+
+        // 계좌 삭제
+        mockMvc.perform(delete("/api/v1/accounts/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("1번 계좌가 삭제되었습니다."));
+    }
+
+}


### PR DESCRIPTION
입출금 계좌 
- 등록
- 단건/다건 조회
- 삭제 
구현했습니다.

현실에서 계좌 정보를 수정하는 경우가 드물기 때문에, 수정 기능은 제외하였습니다.

