### PR TITLE
add acctrac, cookie auth, close #90

### DIFF
--- a/backend/src/main/java/com/back/domain/transactions/Dto/AccountTransactionDto.java
+++ b/backend/src/main/java/com/back/domain/transactions/Dto/AccountTransactionDto.java
@@ -1,0 +1,30 @@
+package com.back.domain.transactions.Dto;
+
+import com.back.domain.transactions.entity.AccountTransaction;
+import com.back.domain.transactions.entity.Transaction;
+
+import java.time.LocalDateTime;
+
+public record AccountTransactionDto(
+        int id,
+        int accountId,
+        String type,
+        int amount,
+        String content,
+        LocalDateTime date,
+        LocalDateTime createDate,
+        LocalDateTime modifyDate
+) {
+    public AccountTransactionDto(AccountTransaction accountTransaction) {
+        this(
+                accountTransaction.getId(),
+                accountTransaction.getAccount().getId(),
+                accountTransaction.getType().toString(),
+                accountTransaction.getAmount(),
+                accountTransaction.getContent(),
+                accountTransaction.getDate(),
+                accountTransaction.getCreateDate(),
+                accountTransaction.getModifyDate()
+        );
+    }
+}

--- a/backend/src/main/java/com/back/domain/transactions/Dto/CreateAccTracRequestDto.java
+++ b/backend/src/main/java/com/back/domain/transactions/Dto/CreateAccTracRequestDto.java
@@ -1,0 +1,17 @@
+package com.back.domain.transactions.Dto;
+
+public record CreateAccTracRequestDto(
+        int accountId,
+        String type,
+        int amount,
+        String content,
+        String date
+) {
+    public CreateAccTracRequestDto(int accountId, String type, int amount, String content, String date) {
+        this.accountId = accountId;
+        this.type = type;
+        this.amount = amount;
+        this.content = content;
+        this.date = date;
+    }
+}

--- a/backend/src/main/java/com/back/domain/transactions/controller/ApiV1AccountTransactionController.java
+++ b/backend/src/main/java/com/back/domain/transactions/controller/ApiV1AccountTransactionController.java
@@ -1,0 +1,82 @@
+package com.back.domain.transactions.controller;
+
+import com.back.domain.account.entity.Account;
+import com.back.domain.transactions.Dto.AccountTransactionDto;
+import com.back.domain.transactions.Dto.CreateAccTracRequestDto;
+import com.back.domain.transactions.dto.CreateTransactionRequestDto;
+import com.back.domain.transactions.dto.TransactionDto;
+import com.back.domain.transactions.dto.UpdateTransactionRequestDto;
+import com.back.domain.transactions.entity.AccountTransaction;
+import com.back.domain.transactions.entity.Transaction;
+import com.back.domain.transactions.service.AccountTransactionService;
+import com.back.domain.transactions.service.TransactionService;
+import com.back.global.rsData.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/transactions/account")
+@Tag(name = "AccountTransactions", description = "거래(계좌) 컨트롤러")
+public class ApiV1AccountTransactionController {
+    private final AccountTransactionService acctTransactionService;
+
+    // 거래 등록
+    @PostMapping
+    @Transactional
+    @Operation(summary = "거래 등록")
+    public RsData<AccountTransactionDto> createTransaction(
+            @RequestBody CreateAccTracRequestDto createAccTracRequestDto
+            ) {
+        AccountTransaction accountTransaction = acctTransactionService.createAccountTransaction(createAccTracRequestDto);
+        AccountTransactionDto accountTransactionDto = new AccountTransactionDto(accountTransaction);
+        return new RsData<>("200-1", "거래가 등록되었습니다.", accountTransactionDto);
+    }
+
+    // 거래 목록 조회
+    @GetMapping
+    @Transactional(readOnly = true)
+    @Operation(summary = "거래 목록 조회")
+    public RsData<List<AccountTransactionDto>> getTransactions() {
+        List<AccountTransaction> accountTransactions = acctTransactionService.findAll();
+        List<AccountTransactionDto> accountTransactionDtos = accountTransactions.stream().map(AccountTransactionDto::new).toList();
+        return new RsData<>("200-1", "거래 목록을 조회했습니다.", accountTransactionDtos);
+    }
+
+    // 거래 단건 조회
+    @GetMapping("/{id}")
+    @Transactional(readOnly = true)
+    @Operation(summary = "거래 단건 조회")
+    public RsData<AccountTransactionDto> getTransaction(@PathVariable int id) {
+        AccountTransaction accountTransaction = acctTransactionService.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("해당 id의 거래가 없습니다. id: " + id));
+        AccountTransactionDto accountTransactionDto = new AccountTransactionDto(accountTransaction);
+        return new RsData<>("200-1", id + "번 거래를 조회했습니다.", accountTransactionDto);
+    }
+
+    // 거래 삭제
+    @DeleteMapping("/{id}")
+    @Transactional
+    @Operation(summary = "거래 삭제")
+    public RsData<AccountTransactionDto> deleteTransaction(@PathVariable int id) {
+        AccountTransaction accountTransaction = acctTransactionService.deleteById(id);
+        AccountTransactionDto accountTransactionDto = new AccountTransactionDto(accountTransaction);
+        return new RsData<>("200-1", id + "번 거래를 삭제했습니다.", accountTransactionDto);
+    }
+
+    // 특정 계좌의 거래 목록 조회
+    @GetMapping("/search/{accountId}")
+    @Transactional(readOnly = true)
+    @Operation(summary = "특정 계좌의 거래 목록 조회")
+    public RsData<List<AccountTransactionDto>> getTransactionsByAccount(@PathVariable int accountId) {
+        List<AccountTransaction> accountTransactions = acctTransactionService.findByAccountId(accountId);
+        List<AccountTransactionDto> accountTransactionDtos = accountTransactions.stream().map(AccountTransactionDto::new).toList();
+        return new RsData<>("200-1", accountId + "번 계좌의 거래 목록을 조회했습니다.", accountTransactionDtos);
+    }
+}

--- a/backend/src/main/java/com/back/domain/transactions/controller/ApiV1TransactionController.java
+++ b/backend/src/main/java/com/back/domain/transactions/controller/ApiV1TransactionController.java
@@ -17,7 +17,7 @@ import java.util.NoSuchElementException;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/transactions")
+@RequestMapping("/api/v1/transactions/asset")
 @Tag(name = "Transactions", description = "거래 컨트롤러")
 public class ApiV1TransactionController {
     private final TransactionService transactionService;
@@ -76,7 +76,7 @@ public class ApiV1TransactionController {
     }
 
     // 특정 자산의 거래 목록 조회
-    @GetMapping("/assets/{assetId}")
+    @GetMapping("/search/{assetId}")
     @Transactional(readOnly = true)
     @Operation(summary = "특정 자산의 거래 목록 조회")
     public RsData<List<TransactionDto>> getTransactionsByAsset(@PathVariable int assetId) {
@@ -84,16 +84,4 @@ public class ApiV1TransactionController {
         List<TransactionDto> transactionDtos = transactions.stream().map(TransactionDto::new).toList();
         return new RsData<>("200-1", assetId + "번 자산의 거래 목록을 조회했습니다.", transactionDtos);
     }
-
-    // 특정 계좌의 거래 목록 조회
-    @GetMapping("/accounts/{accountId}")
-    @Transactional(readOnly = true)
-    @Operation(summary = "특정 계좌의 거래 목록 조회")
-    public RsData<List<TransactionDto>> getTransactionsByAccount(@PathVariable int accountId) {
-        List<Transaction> transactions = transactionService.findByAccountId(accountId);
-        List<TransactionDto> transactionDtos = transactions.stream().map(TransactionDto::new).toList();
-        return new RsData<>("200-1", accountId + "번 계좌의 거래 목록을 조회했습니다.", transactionDtos);
-    }
-
-
 } 

--- a/backend/src/main/java/com/back/domain/transactions/entity/AccountTransaction.java
+++ b/backend/src/main/java/com/back/domain/transactions/entity/AccountTransaction.java
@@ -1,0 +1,27 @@
+package com.back.domain.transactions.entity;
+
+import com.back.domain.account.entity.Account;
+import com.back.global.jpa.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+public class AccountTransaction extends BaseEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id",nullable = false)
+    private Account account;
+
+    @Enumerated(EnumType.STRING)
+    private TransactionType type; // 거래 유형
+
+    private int amount; // 거래량
+    private String content; // 필요 시 메모
+    private LocalDateTime date; // 체결일
+}

--- a/backend/src/main/java/com/back/domain/transactions/entity/TransactionType.java
+++ b/backend/src/main/java/com/back/domain/transactions/entity/TransactionType.java
@@ -1,9 +1,6 @@
 package com.back.domain.transactions.entity;
 
 public enum TransactionType {
-    DEPOSIT,    // 입금
-    WITHDRAWAL, // 출금
-    TRANSFER,   // 이체
-    BUY,        // 매수 (주식 등)
-    SELL        // 매도 (주식 등)
+    ADD,
+    REMOVE
 } 

--- a/backend/src/main/java/com/back/domain/transactions/repository/AccountTransactionRepository.java
+++ b/backend/src/main/java/com/back/domain/transactions/repository/AccountTransactionRepository.java
@@ -1,0 +1,12 @@
+package com.back.domain.transactions.repository;
+
+import com.back.domain.account.entity.Account;
+import com.back.domain.transactions.entity.AccountTransaction;
+import com.back.domain.transactions.entity.Transaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AccountTransactionRepository extends JpaRepository<AccountTransaction, Integer> {
+    List<AccountTransaction> findByAccountId(int accountId);
+}

--- a/backend/src/main/java/com/back/domain/transactions/service/AccountTransactionService.java
+++ b/backend/src/main/java/com/back/domain/transactions/service/AccountTransactionService.java
@@ -1,0 +1,59 @@
+package com.back.domain.transactions.service;
+
+import com.back.domain.account.entity.Account;
+import com.back.domain.account.repository.AccountRepository;
+import com.back.domain.transactions.Dto.CreateAccTracRequestDto;
+import com.back.domain.transactions.entity.AccountTransaction;
+import com.back.domain.transactions.entity.Transaction;
+import com.back.domain.transactions.entity.TransactionType;
+import com.back.domain.transactions.repository.AccountTransactionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AccountTransactionService {
+    private final AccountTransactionRepository accountTransactionRepository;
+    private final AccountRepository accountRepository;
+
+    // 거래 생성
+    public AccountTransaction createAccountTransaction(CreateAccTracRequestDto dto) {
+        Account account = accountRepository.findById(dto.accountId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 자산입니다."));
+
+        AccountTransaction accountTransaction = AccountTransaction.builder()
+                .account(account)
+                .type(TransactionType.valueOf(dto.type()))
+                .amount(dto.amount())
+                .content(dto.content())
+                .date(LocalDateTime.parse(dto.date()))
+                .build();
+
+        return accountTransactionRepository.save(accountTransaction);
+    }
+
+    public List<AccountTransaction> findByAccountId(int accountId) {
+        // 자산이 존재하는지 확인
+        accountRepository.findById(accountId)
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 자산입니다. id: " + accountId));
+
+        return accountTransactionRepository.findByAccountId(accountId);
+    }
+
+    // ------- 일반 서비스 -------- //
+    public long count() { return accountTransactionRepository.count();}
+    public void flush() { accountTransactionRepository.flush();}
+    public AccountTransaction deleteById(int id) {
+        AccountTransaction accountTransaction = accountTransactionRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 id의 거래가 없습니다. id:" + id));
+        accountTransactionRepository.deleteById(id);
+        return accountTransaction;
+    }
+    public List<AccountTransaction> findAll() { return accountTransactionRepository.findAll();}
+    public Optional<AccountTransaction> findById(int id) { return accountTransactionRepository.findById(id);}
+}

--- a/backend/src/main/java/com/back/global/initData/BaseInitData.java
+++ b/backend/src/main/java/com/back/global/initData/BaseInitData.java
@@ -9,8 +9,10 @@ import com.back.domain.goal.entity.Goal;
 import com.back.domain.goal.repository.GoalRepository;
 import com.back.domain.member.entity.Member;
 import com.back.domain.member.repository.MemberRepository;
+import com.back.domain.transactions.entity.AccountTransaction;
 import com.back.domain.transactions.entity.Transaction;
 import com.back.domain.transactions.entity.TransactionType;
+import com.back.domain.transactions.repository.AccountTransactionRepository;
 import com.back.domain.transactions.repository.TransactionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,6 +36,7 @@ public class BaseInitData {
     private final AssetRepository assetRepository;
     private final TransactionRepository transactionRepository;
     private final GoalRepository goalRepository;
+    private final AccountTransactionRepository accountTransactionRepository;
 
     @Autowired
     @Lazy
@@ -49,6 +52,7 @@ public class BaseInitData {
             self.accountInit();
             self.assetInit();
             self.transactionInit();
+            self.accountTransactionInit();
             self.goalInit();
         };
     }
@@ -167,15 +171,34 @@ public class BaseInitData {
 
         //유저1
         Asset asset1 = assetRepository.findById(1).get();
-        transactionRepository.save(new Transaction(asset1, TransactionType.DEPOSIT, 1000, "1입금", LocalDateTime.of(2100, 1, 1, 0, 0, 0)));
+        transactionRepository.save(new Transaction(asset1, TransactionType.ADD, 1000, "1입금", LocalDateTime.of(2100, 1, 1, 0, 0, 0)));
 
         //유저1
         Asset asset2 = assetRepository.findById(4).get();
-        transactionRepository.save(new Transaction(asset2, TransactionType.DEPOSIT, 1000, "2입금", LocalDateTime.of(2100, 1, 1, 0, 0, 0)));
+        transactionRepository.save(new Transaction(asset2, TransactionType.ADD, 1000, "2입금", LocalDateTime.of(2100, 1, 1, 0, 0, 0)));
 
         //유저1
         Asset asset3 = assetRepository.findById(7).get();
-        transactionRepository.save(new Transaction(asset3, TransactionType.DEPOSIT, 1000, "3입금", LocalDateTime.of(2100, 1, 1, 0, 0, 0)));
+        transactionRepository.save(new Transaction(asset3, TransactionType.ADD, 1000, "3입금", LocalDateTime.of(2100, 1, 1, 0, 0, 0)));
+    }
+
+    @Transactional
+    @Profile("!test")
+    public void accountTransactionInit() {
+        if(accountTransactionRepository.count() > 0)
+            return;
+
+        //유저1
+        Account account1 = accountRepository.findById(1).get();
+        accountTransactionRepository.save(new AccountTransaction(account1, TransactionType.ADD, 1000, "1입금", LocalDateTime.of(2100, 1, 1, 0, 0, 0)));
+
+        //유저1
+        Account account2 = accountRepository.findById(3).get();
+        accountTransactionRepository.save(new AccountTransaction(account2, TransactionType.ADD, 1000, "2입금", LocalDateTime.of(2100, 1, 1, 0, 0, 0)));
+
+        //유저1
+        Account account3 = accountRepository.findById(5).get();
+        accountTransactionRepository.save(new AccountTransaction(account3, TransactionType.ADD, 1000, "3입금", LocalDateTime.of(2100, 1, 1, 0, 0, 0)));
     }
 
     @Transactional

--- a/backend/src/main/java/com/back/global/security/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/back/global/security/jwt/JwtAuthenticationFilter.java
@@ -14,6 +14,7 @@ import org.springframework.security.web.authentication.WebAuthenticationDetailsS
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+import jakarta.servlet.http.Cookie;
 
 import java.io.IOException;
 
@@ -65,6 +66,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
             return bearerToken.substring(7); // "Bearer " 제거
         }
+
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if ("accessToken".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+
         return null;
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -15,7 +15,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     properties:
       hibernate:
         format_sql: true

--- a/backend/src/test/java/com/back/domain/transactions/service/TransactionServiceTest.java
+++ b/backend/src/test/java/com/back/domain/transactions/service/TransactionServiceTest.java
@@ -50,7 +50,7 @@ class TransactionServiceTest {
 
         // 6. 결과 검증
         assertThat(result.getAsset().getId()).isEqualTo(1);
-        assertThat(result.getType()).isEqualTo(TransactionType.DEPOSIT);
+        assertThat(result.getType()).isEqualTo(TransactionType.ADD);
         assertThat(result.getAmount()).isEqualTo(1000);
         assertThat(result.getContent()).isEqualTo("테스트");
         assertThat(result.getDate()).isEqualTo(LocalDateTime.parse("2024-07-23T15:00:00"));


### PR DESCRIPTION
- accessToken이 로컬 스토리지가 아닌 Cookie에 저장되게 수정.
- Cookie에서 accessToken을 불러올 수 있도록 수정

- tranaction 엔티티 타입 구조 변경
  - 기존 DEPOSIT, BUY, SELL... -> ADD, REMOVE 2개로 변경
  - 수정 사항에 맞게 테스트 변경.
- 계좌의 거래를 관리하는 AccountTransaction 따로 추가
  - 기존 구조로는 accountId, assetId가 중복될 경우 처리 불가능.
