### PR TITLE
사용자 페이지 백엔드 개선

### DIFF
--- a/backend/src/main/java/com/back/domain/account/controller/ApiV1AccountController.java
+++ b/backend/src/main/java/com/back/domain/account/controller/ApiV1AccountController.java
@@ -46,7 +46,6 @@ public class ApiV1AccountController {
                 RsData<>("200-1", "계좌 목록을 조회했습니다.", accountDtos);
     }
 
-
     @GetMapping("/{accountId}")
     @Operation(summary = "계좌 단건 조회", description = "계좌 단건 조회")
     public RsData<AccountDto> getAccount(@AuthenticationPrincipal CustomUserDetails userDetails,@PathVariable int accountId){

--- a/backend/src/main/java/com/back/domain/asset/controller/ApiV1AssetController.java
+++ b/backend/src/main/java/com/back/domain/asset/controller/ApiV1AssetController.java
@@ -6,9 +6,11 @@ import com.back.domain.asset.Dto.UpdateAssetRequestDto;
 import com.back.domain.asset.entity.Asset;
 import com.back.domain.asset.service.AssetService;
 import com.back.global.rsData.RsData;
+import com.back.global.security.jwt.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -78,6 +80,20 @@ public class ApiV1AssetController {
                 "200-1",
                 "%d번 자산을 수정했습니다.".formatted(updateAssetRequestDto.id()),
                 assetDto
+        );
+    }
+
+    @GetMapping("/member")
+    @Operation(summary = "사용자 기반 자산 목록 조회")
+    public RsData<List<AssetDto>> getAssetsByCurrentMember(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        int memberId = userDetails.getMember().getId();
+
+        List<Asset> assets = assetService.getAssetsByMemberId(memberId);
+        List<AssetDto> assetDtos = assets.stream().map(AssetDto::new).toList();
+        return new RsData<>(
+                "200-1",
+                "%d번 사용자의 자산 목록을 조회했습니다.".formatted(memberId),
+                assetDtos
         );
     }
 }

--- a/backend/src/main/java/com/back/domain/asset/repository/AssetRepository.java
+++ b/backend/src/main/java/com/back/domain/asset/repository/AssetRepository.java
@@ -3,5 +3,8 @@ package com.back.domain.asset.repository;
 import com.back.domain.asset.entity.Asset;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface AssetRepository extends JpaRepository<Asset, Integer> {
+    List<Asset> findAllByMemberId(int memberId);
 }

--- a/backend/src/main/java/com/back/domain/asset/service/AssetService.java
+++ b/backend/src/main/java/com/back/domain/asset/service/AssetService.java
@@ -70,5 +70,11 @@ public class AssetService {
         return assetRepository.save(asset);
     }
 
+    @Transactional(readOnly = true)
+    public List<Asset> getAssetsByMemberId(int memberId) {
+        return assetRepository.findAllByMemberId(memberId);
+    }
+
+    @Transactional
     public void flush() {assetRepository.flush();}
 }

--- a/backend/src/main/java/com/back/domain/member/controller/SnapshotController.java
+++ b/backend/src/main/java/com/back/domain/member/controller/SnapshotController.java
@@ -5,11 +5,14 @@ import com.back.domain.member.entity.Member;
 import com.back.domain.member.service.SnapshotService;
 import com.back.domain.member.service.MemberService;
 import com.back.global.rsData.RsData;
+import com.back.global.security.jwt.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/v1/snapshot")
@@ -18,19 +21,19 @@ public class SnapshotController {
     private final SnapshotService snapshotService;
     private final MemberService memberService;
 
-    @PostMapping("/save/{memberId}")
-    public RsData<?> saveSnapshot(@PathVariable int memberId, @RequestParam Long totalAsset) {
-        Member member = memberService.findById(memberId)
-                .orElseThrow(() -> new NoSuchElementException("해당 id의 사용자가 없습니다." + memberId));
+    @PostMapping("/save")
+    public RsData<?> saveSnapshot(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestParam Long totalAsset) {
+        Member member = Optional.ofNullable(userDetails.getMember())
+                .orElseThrow(() -> new IllegalStateException("인증된 사용자 정보가 없습니다."));
 
         snapshotService.saveMonthlySnapshot(member, totalAsset);
         return new RsData<>("200-1", "스냅샷을 저장했습니다.", totalAsset);
     }
 
-    @GetMapping("/{memberId}")
-    public RsData<List<SnapshotResponse>> getSnapshots(@PathVariable int memberId) {
-        Member member = memberService.findById(memberId)
-                .orElseThrow(() -> new NoSuchElementException("해당 id의 사용자가 없습니다." + memberId));
+    @GetMapping()
+    public RsData<List<SnapshotResponse>> getSnapshots(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Member member = Optional.ofNullable(userDetails.getMember())
+                .orElseThrow(() -> new IllegalStateException("인증된 사용자 정보가 없습니다."));
 
         List<SnapshotResponse> snapshots = snapshotService.getSnapshots(member);
         return new RsData<>("200-1", "스냅샷을 정상적으로 불러왔습니다.", snapshots);

--- a/backend/src/main/java/com/back/domain/transactions/controller/ApiV1AccountTransactionController.java
+++ b/backend/src/main/java/com/back/domain/transactions/controller/ApiV1AccountTransactionController.java
@@ -1,7 +1,9 @@
 package com.back.domain.transactions.controller;
 
+import com.back.domain.account.entity.Account;
 import com.back.domain.transactions.dto.AccountTransactionDto;
 import com.back.domain.transactions.dto.CreateAccTracRequestDto;
+import com.back.domain.transactions.dto.TransactionDto;
 import com.back.domain.transactions.entity.AccountTransaction;
 import com.back.domain.transactions.service.AccountTransactionService;
 import com.back.global.rsData.RsData;
@@ -12,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 
 @RestController
@@ -67,5 +70,12 @@ public class ApiV1AccountTransactionController {
         List<AccountTransaction> accountTransactions = acctTransactionService.findByAccountId(accountId);
         List<AccountTransactionDto> accountTransactionDtos = accountTransactions.stream().map(AccountTransactionDto::new).toList();
         return new RsData<>("200-1", accountId + "번 계좌의 거래 목록을 조회했습니다.", accountTransactionDtos);
+    }
+
+    @GetMapping("/search/bulk")
+    @Operation(summary = "계좌 거래 목록 일괄 조회")
+    public RsData<Map<Integer, List<AccountTransactionDto>>> getAccTransactionsBulk(@RequestParam List<Integer> ids) {
+        Map<Integer, List<AccountTransactionDto>> result = acctTransactionService.findAccTransactionsByAccountIds(ids);
+        return new RsData<>("200-1", "계좌 거래를 일괄 조회했습니다.", result);
     }
 }

--- a/backend/src/main/java/com/back/domain/transactions/controller/ApiV1TransactionController.java
+++ b/backend/src/main/java/com/back/domain/transactions/controller/ApiV1TransactionController.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 
 @RestController
@@ -77,5 +78,12 @@ public class ApiV1TransactionController {
         List<Transaction> transactions = transactionService.findByAssetId(assetId);
         List<TransactionDto> transactionDtos = transactions.stream().map(TransactionDto::new).toList();
         return new RsData<>("200-1", assetId + "번 자산의 거래 목록을 조회했습니다.", transactionDtos);
+    }
+
+    @GetMapping("/search/bulk")
+    @Operation(summary = "자산 거래 목록 일괄 조회")
+    public RsData<Map<Integer, List<TransactionDto>>> getTransactionsBulk(@RequestParam List<Integer> ids) {
+        Map<Integer, List<TransactionDto>> result = transactionService.findTransactionsByAssetIds(ids);
+        return new RsData<>("200-1", "자산 거래를 일괄 조회했습니다.", result);
     }
 } 

--- a/backend/src/main/java/com/back/domain/transactions/repository/AccountTransactionRepository.java
+++ b/backend/src/main/java/com/back/domain/transactions/repository/AccountTransactionRepository.java
@@ -9,4 +9,5 @@ import java.util.List;
 
 public interface AccountTransactionRepository extends JpaRepository<AccountTransaction, Integer> {
     List<AccountTransaction> findByAccount_Id(int accountId);
+    List<AccountTransaction> findByAccount_IdIn(List<Integer> accountIds);
 }

--- a/backend/src/main/java/com/back/domain/transactions/repository/TransactionRepository.java
+++ b/backend/src/main/java/com/back/domain/transactions/repository/TransactionRepository.java
@@ -14,6 +14,7 @@ public interface TransactionRepository extends JpaRepository<Transaction, Intege
     
     // 특정 자산의 거래 목록 조회
     List<Transaction> findByAsset_Id(int assetId);
+    List<Transaction> findByAssetIdIn(List<Integer> assetIds);
     
     // 특정 계좌의 거래 목록 조회 (Asset을 통해 Account 연결)
     @Query("SELECT t FROM Transaction t JOIN t.asset a WHERE a.member.id = :accountId")

--- a/backend/src/main/java/com/back/domain/transactions/service/AccountTransactionService.java
+++ b/backend/src/main/java/com/back/domain/transactions/service/AccountTransactionService.java
@@ -3,8 +3,11 @@ package com.back.domain.transactions.service;
 import com.back.domain.account.entity.Account;
 import com.back.domain.account.repository.AccountRepository;
 import com.back.domain.account.service.AccountService;
+import com.back.domain.transactions.dto.AccountTransactionDto;
 import com.back.domain.transactions.dto.CreateAccTracRequestDto;
+import com.back.domain.transactions.dto.TransactionDto;
 import com.back.domain.transactions.entity.AccountTransaction;
+import com.back.domain.transactions.entity.Transaction;
 import com.back.domain.transactions.entity.TransactionType;
 import com.back.domain.transactions.repository.AccountTransactionRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,8 +16,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -70,4 +75,17 @@ public class AccountTransactionService {
 
     @Transactional(readOnly = true)
     public Optional<AccountTransaction> findById(int id) { return accountTransactionRepository.findById(id);}
+
+    // id 목록 기반 조회.
+    // 사용 용이하도록 Dto로 return.
+    @Transactional(readOnly = true)
+    public Map<Integer, List<AccountTransactionDto>> findAccTransactionsByAccountIds(List<Integer> accountIds) {
+        List<AccountTransaction> allTransactions = accountTransactionRepository.findByAccount_IdIn(accountIds);
+
+        return allTransactions.stream()
+                .collect(Collectors.groupingBy(
+                        tx -> tx.getAccount().getId(),
+                        Collectors.mapping(AccountTransactionDto::new, Collectors.toList())
+                ));
+    }
 }

--- a/backend/src/main/java/com/back/domain/transactions/service/TransactionService.java
+++ b/backend/src/main/java/com/back/domain/transactions/service/TransactionService.java
@@ -5,6 +5,7 @@ import com.back.domain.asset.entity.AssetType;
 import com.back.domain.asset.repository.AssetRepository;
 import com.back.domain.account.repository.AccountRepository;
 import com.back.domain.transactions.dto.CreateTransactionRequestDto;
+import com.back.domain.transactions.dto.TransactionDto;
 import com.back.domain.transactions.dto.UpdateTransactionRequestDto;
 import com.back.domain.transactions.entity.Transaction;
 import com.back.domain.transactions.entity.TransactionType;
@@ -14,8 +15,10 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -104,5 +107,17 @@ public class TransactionService {
         }
         
         return transactionRepository.searchTransactions(transactionType, start, end, minAmount, maxAmount);
+    }
+
+    // id 목록 기반 조회.
+    // 사용 용이하도록 Dto로 return.
+    public Map<Integer, List<TransactionDto>> findTransactionsByAssetIds(List<Integer> assetIds) {
+        List<Transaction> allTransactions = transactionRepository.findByAssetIdIn(assetIds);
+
+        return allTransactions.stream()
+                .collect(Collectors.groupingBy(
+                        tx -> tx.getAsset().getId(),
+                        Collectors.mapping(TransactionDto::new, Collectors.toList())
+                ));
     }
 } 

--- a/backend/src/test/java/com/back/domain/member/controller/SnapShotControllerTest.java
+++ b/backend/src/test/java/com/back/domain/member/controller/SnapShotControllerTest.java
@@ -1,7 +1,9 @@
 package com.back.domain.member.controller;
 
 import com.back.domain.member.repository.MemberRepository;
+import com.back.global.security.jwt.JwtUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,16 +33,23 @@ class SnapShotControllerTest {
     @Autowired
     private MemberRepository memberRepository;
 
+    @Autowired
+    JwtUtil jwtutil;
+
+    String token;
     ObjectMapper objectMapper = new ObjectMapper();
 
+    @BeforeEach
+    void setUp() {
+        token = jwtutil.generateToken("user1@user.com", 4);
+    }
 
     @Test
     @DisplayName("스냅샷 등록")
     void createSnapShot() throws Exception {
-        ResultActions resultActions = mockMvc
-                .perform(
-                        post("/api/v1/snapshot/save/1?totalAsset=10000")
-                                .contentType(MediaType.APPLICATION_JSON)
+        mockMvc.perform(post("/api/v1/snapshot/save?totalAsset=10000")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + token)
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.msg").value("스냅샷을 저장했습니다."));
@@ -49,8 +58,9 @@ class SnapShotControllerTest {
     @Test
     @DisplayName("스냅샷 조회")
     void findSnapShot() throws Exception {
-        ResultActions resultActions = mockMvc
-                .perform(get("/api/v1/snapshot/1"))
+        mockMvc.perform(get("/api/v1/snapshot")
+                        .header("Authorization", "Bearer " + token)
+                )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.msg").value("스냅샷을 정상적으로 불러왔습니다."));
     }


### PR DESCRIPTION
- Transaction, AccountTransaction에서 id 리스트 기반 거래 목록 조회 API 추가
- Snapshot의 경우 따로 memberId를 PathVariable로 받지 않고, 현재 인증된 사용자를 사용하도록 변경 
