### PR TITLE
feat(be): memberId를 PathVariable로 사용하지 않고 Asset을 생성하는 API 추가.

### DIFF
--- a/backend/src/main/java/com/back/domain/asset/Dto/CreateWithoutMemberDto.java
+++ b/backend/src/main/java/com/back/domain/asset/Dto/CreateWithoutMemberDto.java
@@ -1,0 +1,22 @@
+package com.back.domain.asset.Dto;
+
+import com.back.domain.member.entity.Member;
+import lombok.Getter;
+import lombok.Setter;
+
+public record CreateWithoutMemberDto(
+        String name,
+        String assetType,
+        Long assetValue
+) {
+    public CreateWithoutMemberDto(
+                                 String name,
+                                 String assetType,
+                                 Long assetValue
+    )
+    {
+        this.name = name;
+        this.assetType = assetType;
+        this.assetValue = assetValue;
+    }
+}

--- a/backend/src/main/java/com/back/domain/asset/controller/ApiV1AssetController.java
+++ b/backend/src/main/java/com/back/domain/asset/controller/ApiV1AssetController.java
@@ -2,6 +2,7 @@ package com.back.domain.asset.controller;
 
 import com.back.domain.asset.Dto.AssetDto;
 import com.back.domain.asset.Dto.CreateAssetRequestDto;
+import com.back.domain.asset.Dto.CreateWithoutMemberDto;
 import com.back.domain.asset.Dto.UpdateAssetRequestDto;
 import com.back.domain.asset.entity.Asset;
 import com.back.domain.asset.service.AssetService;
@@ -95,5 +96,18 @@ public class ApiV1AssetController {
                 "%d번 사용자의 자산 목록을 조회했습니다.".formatted(memberId),
                 assetDtos
         );
+    }
+
+    @PostMapping("/member")
+    @Operation(summary = "사용자 기반 자산 등록")
+    public RsData<AssetDto> createAssetByCurrentMember(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody CreateWithoutMemberDto createWithoutMemberDto
+    ) {
+        int memberId = userDetails.getMember().getId();
+
+        Asset asset = assetService.createAssetByMember(memberId, createWithoutMemberDto);
+        AssetDto assetDto = new AssetDto(asset);
+        return new RsData<>("200-1", "자산이 등록되었습니다.", assetDto);
     }
 }

--- a/backend/src/main/java/com/back/domain/asset/service/AssetService.java
+++ b/backend/src/main/java/com/back/domain/asset/service/AssetService.java
@@ -1,6 +1,7 @@
 package com.back.domain.asset.service;
 
 import com.back.domain.asset.Dto.CreateAssetRequestDto;
+import com.back.domain.asset.Dto.CreateWithoutMemberDto;
 import com.back.domain.asset.Dto.UpdateAssetRequestDto;
 import com.back.domain.asset.entity.Asset;
 import com.back.domain.asset.entity.AssetType;
@@ -32,6 +33,22 @@ public class AssetService {
                 .name(createAssetRequestDto.name())
                 .assetType(AssetType.valueOf(createAssetRequestDto.assetType()))
                 .assetValue(createAssetRequestDto.assetValue())
+                .build();
+
+        assetRepository.save(asset);
+        return asset;
+    }
+
+    @Transactional
+    public Asset createAssetByMember(int memberId, CreateWithoutMemberDto createWithoutMemberDto) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 회원입니다."));
+
+        Asset asset = Asset.builder()
+                .member(member)
+                .name(createWithoutMemberDto.name())
+                .assetType(AssetType.valueOf(createWithoutMemberDto.assetType()))
+                .assetValue(createWithoutMemberDto.assetValue())
                 .build();
 
         assetRepository.save(asset);


### PR DESCRIPTION
- memberId가 필요 없는 CreateWithoutMemberDto 추가.
- 현재 로그인 된 사용자를 기반으로 하는 Asset 생성 API 추가
- 기능 구현에 맞는 Service 메소드(CreateAssetByMember) 추가.
