### PR TITLE
fix(BE): Refresh Token 관련 보안 문제 개선 

### DIFF
--- a/backend/src/main/java/com/back/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/back/domain/auth/service/AuthService.java
@@ -11,17 +11,19 @@ import com.back.domain.member.repository.MemberRepository;
 import com.back.global.security.jwt.JwtUtil;
 import com.back.global.security.service.RateLimitService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
 import java.time.LocalDateTime;
-import java.util.Date;
+
 
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 @Transactional(readOnly = true)
 public class AuthService {
 
@@ -30,6 +32,7 @@ public class AuthService {
     private final RateLimitService rateLimitService;
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtUtil jwtUtil;
+    private final TokenService tokenService;
 
     public FindAccountResponseDto findAccount(String name, String phoneNumber, String ipAddress) {
         // Rate limit 체크
@@ -118,24 +121,11 @@ public class AuthService {
 
     @Transactional
     public TokenPairDto createTokenPair(Member member) {
-        // 기존 활성화된 토큰 비활성화
-        refreshTokenRepository.deactivateAllTokensByMember(member);
+        // 기존 토큰 무효화
+        tokenService.invalidateAllUserTokens(member);
 
-        // 새로운 Refresh Token 생성
-        String accessToken = jwtUtil.generateToken(member.getEmail(), member.getId());
-        String refreshToken = jwtUtil.generateRefreshToken(member.getEmail(), member.getId());
-
-        // RefreshToken DB에 저장
-        LocalDateTime expiryDate = convertToLocalDateTime(jwtUtil.getExpirationDateFromToken(refreshToken));
-        RefreshToken refreshTokenEntity = RefreshToken.builder()
-                .token(refreshToken)
-                .member(member)
-                .expiryDate(expiryDate)
-                .build();
-
-        refreshTokenRepository.save(refreshTokenEntity);
-
-        return TokenPairDto.of(accessToken, refreshToken);
+        // 새 토큰 쌍 생성 및 저장
+        return tokenService.generateAndSaveTokenPair(member);
     }
 
     // Refresh Token 으로 새 Access Token 생성
@@ -146,39 +136,47 @@ public class AuthService {
             throw new AuthenticationException("유효하지 않은 Refresh Token입니다.");
         }
 
-        // DB에서 토큰 조회
+        // DB에서 토큰 조회후 member 정보 추출
         RefreshToken storedToken = refreshTokenRepository.findValidToken(refreshToken, LocalDateTime.now())
-                .orElseThrow(() -> new AuthenticationException("만료되거나 존재하지 않는 Refresh Token입니다."));
+                .orElseGet(() -> {
+                    handleSuspiciousTokenActivity(refreshToken);
+                    throw new AuthenticationException("토큰 탈취가 의심됩니다. 관리자에게 문의해주세요.");
+                });
 
         Member member = storedToken.getMember();
 
-        // 새 토큰 쌍 생성 (Refresh Token 회전)
-        String newAccessToken = jwtUtil.generateToken(member.getEmail(), member.getId());
-        String newRefreshToken = jwtUtil.generateRefreshToken(member.getEmail(), member.getId());
-
-        // 기존 토큰 업데이트
-        LocalDateTime newExpiryDate = convertToLocalDateTime(jwtUtil.getExpirationDateFromToken(newRefreshToken));
-        storedToken.updateToken(newRefreshToken, newExpiryDate);
-
-        return TokenPairDto.of(newAccessToken, newRefreshToken);
+        // 새 토큰 쌍 생성
+        return tokenService.rotateTokenPair(refreshToken, member);
     }
 
     // 로그아웃 시 Refresh Token 비활성화
     @Transactional
     public void invalidateRefreshToken(String refreshToken) {
-        refreshTokenRepository.deactivateToken(refreshToken);
+        tokenService.invalidateToken(refreshToken);
     }
 
-    //Date를 LocalDateTime으로 변환하는 메서드
-    private LocalDateTime convertToLocalDateTime(Date date) {
-        return date.toInstant()
-                .atZone(java.time.ZoneId.systemDefault())
-                .toLocalDateTime();
-    }
 
     // 사용자 ID로 회원 조회
     public Member findMemberById(int userId) {
         return memberRepository.findByIdAndNotDeleted(userId)
                 .orElseThrow(() -> new AuthenticationException("존재하지 않는 사용자입니다."));
+    }
+
+    private void handleSuspiciousTokenActivity(String suspiciousToken) {
+        try {
+            // 토큰에서 사용자 정보 추출
+            String email = jwtUtil.getEmailFromToken(suspiciousToken);
+
+            // 해당 사용자의 모든 활성 토큰 무효화
+            Member member = memberRepository.findByEmailAndNotDeleted(email)
+                    .orElse(null);
+
+            if (member != null) {
+                tokenService.invalidateAllUserTokens(member);
+                log.warn("의심스러운 토큰 활동 감지: 사용자 {}의 모든 토큰이 무효화되었습니다.", email);
+            }
+        } catch (Exception e) {
+            log.error("의심스러운 토큰 활동 처리 중 오류 발생: {}", e.getMessage());
+        }
     }
 }

--- a/backend/src/main/java/com/back/domain/auth/service/TokenService.java
+++ b/backend/src/main/java/com/back/domain/auth/service/TokenService.java
@@ -1,0 +1,77 @@
+package com.back.domain.auth.service;
+
+import com.back.domain.auth.dto.TokenPairDto;
+import com.back.domain.auth.entity.RefreshToken;
+import com.back.domain.auth.repository.RefreshTokenRepository;
+import com.back.domain.member.entity.Member;
+import com.back.global.security.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TokenService {
+
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    //새로운 토크 쌍 생성, RefreshToken DB에 저장
+    @Transactional
+    public TokenPairDto generateAndSaveTokenPair(Member member) {
+        // 토큰 쌍 생성
+        String accessToken = jwtUtil.generateToken(member.getEmail(), member.getId());
+        String refreshToken = jwtUtil.generateRefreshToken(member.getEmail(), member.getId());
+
+        // RefreshToken DB에 저장
+        saveRefreshTokenToDatabase(refreshToken, member);
+
+        return TokenPairDto.of(accessToken, refreshToken);
+    }
+
+    // 기존 토큰 무효화, 새로운 토큰 쌍 생성
+    @Transactional
+    public TokenPairDto rotateTokenPair(String oldRefreshToken, Member member) {
+        // 기존 토큰 즉시 무효화
+        invalidateToken(oldRefreshToken);
+
+        // 새 토큰 쌍 생성 및 저장
+        return generateAndSaveTokenPair(member);
+    }
+
+    // 토큰 무효화
+    @Transactional
+    public void invalidateToken(String oldRefreshToken) {
+        refreshTokenRepository.deactivateToken(oldRefreshToken);
+    }
+
+    // 사용자의 모든 토큰 무효화
+    @Transactional
+    public void invalidateAllUserTokens(Member member) {
+        refreshTokenRepository.deactivateAllTokensByMember(member);
+    }
+
+    //RefreshToken을 DB에 저장
+    private void saveRefreshTokenToDatabase(String refreshToken, Member member) {
+        LocalDateTime expiryDate = convertToLocalDateTime(jwtUtil.getExpirationDateFromToken(refreshToken));
+        RefreshToken refreshTokenEntity = RefreshToken.builder()
+                .token(refreshToken)
+                .member(member)
+                .expiryDate(expiryDate)
+                .build();
+
+        refreshTokenRepository.save(refreshTokenEntity);
+    }
+
+    // Date를 LocalDateTime으로 변환하는 메서드
+    private LocalDateTime convertToLocalDateTime(Date date) {
+        return date.toInstant()
+                .atZone(java.time.ZoneId.systemDefault())
+                .toLocalDateTime();
+    }
+}


### PR DESCRIPTION
로그아웃 시 기존 발급된 토큰을 무효화하지 않는 문제가 있었음.


1단계: 로그아웃 시 리프레시 토큰 무효화

  - 로그아웃 시 DB에서 토큰 무효화
  - Access Token과 Refresh Token 쿠키 모두 삭제

 2단계: 토큰 회전(Token Rotation) 강화

  - 기존 토큰 즉시 무효화 후 새 토큰 발급
  - 토큰 재사용 방지

 3단계: 토큰 재사용 감지 및 보안 강화

  - 무효화된 토큰 사용 시 탈취 의심으로 판단
  - 해당 사용자의 모든 토큰 즉시 무효화
  - 보안 로그 기록

  4단계: 코드 구조 개선

  - TokenService 분리로 단일 책임 원칙 준수
  - 중복 코드 제거 및 재사용성 향상